### PR TITLE
Update Research Papers and Articles section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ This section contains links to code repositories that demonstrate the implementa
 
 Here, you will find a curated list of research papers, articles, and blog posts related to GPT and its applications. These resources provide in-depth knowledge and insights into the latest advancements in GPT technology and its impact on various domains.
 
-- [Example Research Paper 1](#link-to-paper-1)
-- [Example Research Paper 2](#link-to-paper-2)
-- [Example Article 1](#link-to-article-1)
+#### Retrieval Augmented Generation (RAG)
+- [Retrieval Augmented Generation (RAG): Reducing Hallucinations in GenAI Applications](https://www.pinecone.io/learn/retrieval-augmented-generation/)
+- [Knowledge Graphs & LLMs: Fine-Tuning vs. Retrieval-Augmented Generation](https://neo4j.com/developer-blog/fine-tuning-retrieval-augmented-generation/)
 
 ## Contributing
 


### PR DESCRIPTION
In the **Research Papers and Articles** section, I've added articles related to a trendy application of GPT models with a knowledge database (can be their domain database) known as **Retrieval Augmented Generation (RAG)**. These articles will clearly explain how we can prevent **hallucination** problem in the generation by integrating it with existing domain knowledge available in different formats such as documents or knowledge graph

with that, I've added a subsection in the Research Papers and Articles section named `Retrieval Augmented Generation (RAG)` so that newcomers can easily find and read the categories that they are interested in. What do you think about adding a subsection? @ksupasate I think we can discuss about it.  Adding a subsection to each section is easier to read, and I think that it can address issue #2 as well.